### PR TITLE
Resolve issue #2 : searching header files

### DIFF
--- a/cscope-filter.sh
+++ b/cscope-filter.sh
@@ -23,6 +23,7 @@ make_filtering() {
 	awk '/\.o/ {print $2}' cscope_filtered.log |\
 		sed -e "s:^:$CUR_PATH\/:" |\
 		sed -e 's/\.o/\.c/g' > cscope_filtered.files
+	find $CUR_PATH \( -name '*.h' -o -name '*.s' -o -name '*.S' -o -name '*.dts' -o -name '*.dtsi' \) -print >> cscope_filtered.files
 }
 
 make_cscope() {


### PR DESCRIPTION
Cscope can't search the target which is in the header files.
Because there is no header file paths in the cscope_filtered.files
So, I have add the code which can insert header file paths to the cscope_filtered.files
This commit is made for issue #2

Signed-off-by: JI-HUN KIM jihuun.k@gmail.com
